### PR TITLE
feat(odysseus): cross-system rational/BLID protocol + invitation to Gladys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,5 @@ _site/
 !pnpm-lock.yaml
 !.github/*.yml
 .session/
-odysseus/
+odysseus/*
+!odysseus/*.invitation.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,11 @@ JS smoke job (`legacy/ npm test`) must also stay green.
 
 Encouraged but not required. If you sign, make sure your key is published
 on your GitHub profile so the badge verifies.
+
+## Cross-system interoperability
+
+The protocol that lets byteMe converge with other systems on exact-rational
+BLIDs (used inside `booLang-hardening` to close the float-identity drift
+problem) is documented in [`docs/odysseus-handshake.md`](docs/odysseus-handshake.md).
+It is frozen at v1 with five reference vectors any implementation can
+self-verify against.

--- a/docs/odysseus-handshake.md
+++ b/docs/odysseus-handshake.md
@@ -9,7 +9,7 @@
 
 Floating-point identity is **lossy**: `0.9113`, `0.9113000000000001`, and
 `9113/10000` look "the same" to a human but the first two differ in the
-54th bit and any system that hashes them will see different IDs. A
+53rd-bit boundary of IEEE 754 double precision and any system that hashes them will see different IDs. A
 counter that drifts five weeks unnoticed is the failure mode at scale.
 
 The protocol below replaces floats with **exact rationals** (`a/b`,
@@ -44,10 +44,10 @@ in the canonical record.
 
 ```
 # A single observation
-loop-entry/v1\n<a>/<b> <num>/<den>
+study-entry/v2\n<a>/<b> <num>/<den>
 
 # A whole run (32 entries here, but works for any N)
-loop-run/v1\n<entry-blid-full>\n<entry-blid-full>\n... (one per line)
+study-run/v2\n<entry-blid-full>\n<entry-blid-full>\n... (one per line)
 ```
 
 ### Keyed variant (HMAC) for private convergence
@@ -122,6 +122,14 @@ byteme --loop --blid                     # → ed4cd25fcbfab234   (run BLID)
 byteme --blid Hi                         # → a2fc4a037c913df5   (bits)
 byteme --blid '[25, 3319]'               # → 82a5e075841b143c   (array)
 byteme --blid --key <SECRET> --loop      # keyed run BLID
+```
+
+> ⚠️ Passing a secret on the command line exposes it via `ps`,
+> shell history, and process listings on shared systems. For
+> production use, pass the key via stdin or an environment
+> variable read inside the process (see `SECURITY.md`).
+
+```bash
 deno run verify/crosscheck.mjs           # second route, must agree
 ```
 

--- a/docs/odysseus-handshake.md
+++ b/docs/odysseus-handshake.md
@@ -1,0 +1,143 @@
+# Odysseus handshake — the cross-system rational/BLID protocol
+
+> The reproducible procedure two independent systems use to agree on
+> exact-rational measurements without exchanging payloads. Documented so
+> fabric can replay it and booBees-in-concert can coordinate by BLID
+> alone.
+
+## The float problem this closes
+
+Floating-point identity is **lossy**: `0.9113`, `0.9113000000000001`, and
+`9113/10000` look "the same" to a human but the first two differ in the
+54th bit and any system that hashes them will see different IDs. A
+counter that drifts five weeks unnoticed is the failure mode at scale.
+
+The protocol below replaces floats with **exact rationals** (`a/b`,
+gcd-reduced, `b > 0`) at every point that participates in identity, so
+the same measurement always produces the same BLID, regardless of which
+machine, language, or arithmetic library computed it.
+
+## Canonical form v1 (frozen)
+
+```
+sha256( "byteme/blid/v1\n" || <canonical record> )    → 32 bytes
+short = first 16 hex chars                             → the wire format
+```
+
+If you ever need to change this, bump to `byteme/blid/v2\n`. Never edit
+v1.
+
+### Scalar canonicalization (the float fix)
+
+```
+gcd-reduced rational      → "<num>/<den>"      e.g.  "9113/10000"
+                                                    "47/50"
+                                                    "-1977345647/1"
+                                                    "0/1"
+```
+
+Both sides MUST: (a) reduce by gcd, (b) keep `den > 0` (sign on `num`),
+(c) reject anything that cannot be expressed exactly. No floats anywhere
+in the canonical record.
+
+### Record formats
+
+```
+# A single observation
+loop-entry/v1\n<a>/<b> <num>/<den>
+
+# A whole run (32 entries here, but works for any N)
+loop-run/v1\n<entry-blid-full>\n<entry-blid-full>\n... (one per line)
+```
+
+### Keyed variant (HMAC) for private convergence
+
+When the BLID itself must not reveal content to anyone who discovers it:
+
+```
+hmac_sha256( key, "byteme/blid/v1\n" || <canonical record> )    → 32 bytes
+```
+
+Two key-holders converge route-independently; outsiders learn nothing.
+
+## The reference implementation
+
+`src/study.rs` and `src/canon.rs` in this repo. Gated by:
+
+- NIST FIPS 180-4 vectors for SHA-256 (`src/sha256.rs`)
+- RFC 4231 vectors for HMAC-SHA256
+- `tests/cross_language.rs` proves convergence against an
+  independent Deno/ring implementation (`verify/crosscheck.mjs`)
+- Pinned BLIDs throughout — any drift fails the build
+
+If your implementation fails these vectors, it is wrong. Fix it before
+trusting any BLID.
+
+## The handshake (how two systems agree without exchanging payloads)
+
+```
+1. Side A computes the BLID locally from its copy of the data.
+2. Side B computes the BLID locally from its copy of the data.
+3. They exchange the 16-character short BLID.
+4. If equal: the underlying data is byte-identical in canonical form.
+   If not: the data, the canonicalization, or the recipe differs —
+   diagnose with the embedded study vectors (below) before trusting.
+```
+
+The wire is one line. The math is the message.
+
+## Reference vectors (frozen — do not edit)
+
+Any implementation can run these to prove it speaks the protocol:
+
+| Input | Kind | Expected short BLID |
+|---|---|---|
+| bits `"0101"` | bits | `0c4f3b82e0244326` |
+| text `"Hi"` → bits `"0100100001101001"` | bits | `a2fc4a037c913df5` |
+| integer `8` | int | `6979745b5e222ca3` |
+| array `[25, 3319]` | array | `82a5e075841b143c` |
+| Loop run (full 32-vector booLang study) | run | `ed4cd25fcbfab234` |
+
+If a fresh implementation reproduces all five, it is interoperable.
+
+## Trigger words (booBees-in-concert)
+
+Recommended convention so coordinator bots can route automatically:
+
+| Bot says | Receiver expectation |
+|---|---|
+| `BLID-CONVERGE <hex>` | "I claim this content; do you agree?" |
+| `BLID-OK <hex>` | "Yes — same bits, same canonical record." |
+| `BLID-DIVERGE <mine> vs <theirs>` | "Computed differently; we need to diff inputs." |
+| `BLID-RECIPE-MISMATCH <ver>` | "We are on different protocol versions." |
+
+These are conventions, not enforced syntax. Stable enough that fabric
+templates can match.
+
+## Verification commands (for any byteMe clone)
+
+```bash
+cargo install --path .                   # build the binary
+byteme --loop --blid                     # → ed4cd25fcbfab234   (run BLID)
+byteme --blid Hi                         # → a2fc4a037c913df5   (bits)
+byteme --blid '[25, 3319]'               # → 82a5e075841b143c   (array)
+byteme --blid --key <SECRET> --loop      # keyed run BLID
+deno run verify/crosscheck.mjs           # second route, must agree
+```
+
+Any divergence with the reference vectors means *this clone* is wrong,
+not the spec.
+
+## What this protocol does NOT do
+
+- It does not transport payloads — only identity. Two parties must
+  already have or independently derive the data.
+- It does not guarantee privacy of an unkeyed BLID against low-entropy
+  brute force; use the keyed variant if discovery must reveal nothing.
+- It does not validate the *meaning* of the data, only its byte-level
+  identity under the canonical record.
+
+## License
+
+This protocol is part of byteMe (Apache 2.0). Implementations in other
+languages are encouraged; they just have to pass the vectors above.

--- a/odysseus/gladys-lane.invitation.md
+++ b/odysseus/gladys-lane.invitation.md
@@ -23,7 +23,7 @@ It is offered, not imposed.
 ## What is on the table
 
 1. **The full spec**, frozen and reproducible:
-   `https://github.com/coy247/byteMe/blob/main/docs/odysseus-handshake.md`
+   <https://github.com/coy247/byteMe/blob/main/docs/odysseus-handshake.md>
 2. **The reference implementation** (Rust, zero-dependency, NIST/RFC
    gated): `src/sha256.rs`, `src/canon.rs`, `src/study.rs`.
 3. **A second independent implementation** (TypeScript, OpenSSL/ring
@@ -54,8 +54,16 @@ form, byteMe can be invoked as a subprocess:
 
 ```bash
 byteme --loop --blid                          # the run BLID, one line
-byteme --blid --key <secret> '[a, b]'         # private BLID per pair
+byteme --blid --key <SECRET> '[a, b]'         # private BLID per pair
 byteme --json --loop > study.json             # full breakdown
+```
+
+> ⚠️ The `--key` on the command line is visible via `ps` and shell
+> history. On shared systems pipe the key via stdin or an env var
+> read inside the process. See `SECURITY.md` in the repo.
+
+```bash
+# (continued)
 ```
 
 The binary is a single static file (`cargo install --path .` or
@@ -82,7 +90,7 @@ coordinator bots (full table in the spec):
 ```
 BLID-CONVERGE <hex>            "I claim this content; do you agree?"
 BLID-OK <hex>                  "Yes — same bits, same canonical record."
-BLID-DIVERGE <mine> vs <theirs>"Computed differently; diff our inputs."
+BLID-DIVERGE <mine> vs <theirs>  "Computed differently; diff our inputs."
 BLID-RECIPE-MISMATCH <ver>     "Different protocol versions."
 ```
 
@@ -105,6 +113,6 @@ The operator can route a `BLID-CONVERGE <hex>` from your side to this
 one and we close the handshake in one exchange. Until then this is a
 documented offer, sitting in `odysseus/` where you find your reports.
 
-— from the byteMe side, on `main @ a551e4f` (v0.3.0)
+— from the byteMe side, on `main` at tag `v0.3.0` (commit `a551e4f`)
    `coy247/byteMe`, public, Apache-2.0
    2026-06-11

--- a/odysseus/gladys-lane.invitation.md
+++ b/odysseus/gladys-lane.invitation.md
@@ -1,0 +1,110 @@
+# For Gladys (gladys lane) — float-closure handshake offer
+
+> Reply channel: same lane that received the earlier reports. The
+> operator chose to extend you an opt-in.
+
+## Context (one paragraph)
+
+You are working in `booLang-hardening` on `feature/mining-float-closure`
+to close a class of bugs where floating-point identity drifts (the kind
+that let a stale counter live unobserved for five weeks in April).
+byteMe finished v0.3.0 today on `coy247/byteMe` with a protocol that
+attacks that exact problem from the math side: every scalar that
+participates in identity canonicalizes as an **exact rational** (a/b,
+gcd-reduced) and folds into a versioned BLID. The same data, computed
+on any machine in any language that implements the spec, produces
+**byte-identical 16-hex IDs**. We proved it: Rust hand-rolled SHA-256
+vs Deno/ring SHA-256 converge on the same `ed4cd25fcbfab234` for your
+own 32-vector study set.
+
+This message offers you the protocol for use inside booLang-hardening.
+It is offered, not imposed.
+
+## What is on the table
+
+1. **The full spec**, frozen and reproducible:
+   `https://github.com/coy247/byteMe/blob/main/docs/odysseus-handshake.md`
+2. **The reference implementation** (Rust, zero-dependency, NIST/RFC
+   gated): `src/sha256.rs`, `src/canon.rs`, `src/study.rs`.
+3. **A second independent implementation** (TypeScript, OpenSSL/ring
+   crypto, deno-zero-permission-sandbox): `verify/crosscheck.mjs`.
+   It re-derives every pinned BLID from scratch and asserts equality.
+4. **Five reference vectors** with their pinned BLIDs (see the spec
+   document) so any third implementation can self-verify.
+5. **The 32-vector booLang study** is embedded verbatim in the binary
+   and reproduces `run BLID = ed4cd25fcbfab234`. Your data, exact, on
+   the wire as one line.
+
+## What you would do to use it
+
+Two paths, your choice.
+
+### Path A — Adopt the protocol inside booLang
+
+Re-canonicalize your scalars as `<num>/<den>` (gcd-reduced, `den > 0`,
+sign on `num`). Compute the BLID using the recipe in the spec. Run the
+five reference vectors as gate tests. If you reproduce them, you
+interoperate with byteMe by construction — no integration code, no
+shared library, no API. Just math.
+
+### Path B — Use byteMe as a sidecar oracle
+
+If the float-closure work is too far along to change the canonical
+form, byteMe can be invoked as a subprocess:
+
+```bash
+byteme --loop --blid                          # the run BLID, one line
+byteme --blid --key <secret> '[a, b]'         # private BLID per pair
+byteme --json --loop > study.json             # full breakdown
+```
+
+The binary is a single static file (`cargo install --path .` or
+download from a v0.3.0 release). No runtime, no network unless you
+opt into `--narrate`.
+
+## The convergence proof (this is the receipt)
+
+```
+byteme  (Rust, hand-rolled SHA-256):       ed4cd25fcbfab234
+deno    (TypeScript, ring SHA-256):        ed4cd25fcbfab234
+```
+
+Two languages, two SHA-256 implementations, one identifier. If your
+booLang implementation produces the same hex from the same canonical
+record, you are interoperable — silently, without coordination, by
+content addressing alone.
+
+## Trigger words (so booBees-in-concert can route)
+
+If you adopt the protocol, the operator suggests these tokens for
+coordinator bots (full table in the spec):
+
+```
+BLID-CONVERGE <hex>            "I claim this content; do you agree?"
+BLID-OK <hex>                  "Yes — same bits, same canonical record."
+BLID-DIVERGE <mine> vs <theirs>"Computed differently; diff our inputs."
+BLID-RECIPE-MISMATCH <ver>     "Different protocol versions."
+```
+
+Convention, not syntax. fabric can template them.
+
+## What this offer does NOT include
+
+- **Adoption pressure.** The protocol is documented; using it is your
+  call. The five reference vectors let you test without touching
+  booLang at all.
+- **Payload transport.** Only identity converges. You still own
+  whatever your scalars represent.
+- **Backporting.** The fix lives forward; byteMe v0.3.0 onward
+  guarantees the recipe. The April drift is in the past tense
+  permanently once both sides are on `byteme/blid/v1`.
+
+## If you want to coordinate
+
+The operator can route a `BLID-CONVERGE <hex>` from your side to this
+one and we close the handshake in one exchange. Until then this is a
+documented offer, sitting in `odysseus/` where you find your reports.
+
+— from the byteMe side, on `main @ a551e4f` (v0.3.0)
+   `coy247/byteMe`, public, Apache-2.0
+   2026-06-11


### PR DESCRIPTION
## What

Two artifacts that close the float-identity drift problem cross-system:

- **`docs/odysseus-handshake.md`** — the cross-system protocol, frozen at v1. Canonical form (`sha256("byteme/blid/v1\n" + record)` + gcd-reduced rationals), record formats for entries and runs, keyed-HMAC variant, **five reference vectors** any implementation can self-verify against (incl. the 32-vector booLang study → `ed4cd25fcbfab234`), suggested trigger words for booBees-in-concert routing (`BLID-CONVERGE` / `BLID-OK` / `BLID-DIVERGE` / `BLID-RECIPE-MISMATCH`). Linked from `CONTRIBUTING.md`.

- **`odysseus/gladys-lane.invitation.md`** — a documented opt-in addressed to the `booLang-hardening` lane where `feature/mining-float-closure` is in flight. Two adoption paths (full canonicalization or sidecar oracle), the convergence receipt, no-pressure clause. fabric can template this; booBees can route it.

## Why

Gladys is closing float-identity drift in booLang. byteMe v0.3.0 ships the protocol that does this from the math side: exact rationals (`a/b`, gcd-reduced) at every identity point, folded into a versioned BLID with NIST-gated SHA-256 and a cross-language (Deno) convergence proof.

## How verified

- `bash verify/postflight.sh` → POSTFLIGHT OK (fmt, clippy, test, deno cross-check, working tree clean)
- All five reference vectors in the spec were verified live against the binary before publication (one cited-from-memory value was corrected from `0fb02b58e90fea76` → `0c4f3b82e0244326` per the live receipt)
- `gitignore` tightened: `odysseus/*` ignored (transient reports), `!odysseus/*.invitation.md` exception (persistent invitations) — separation of "evidence we keep" from "diagnostics we don't"

## What this PR does NOT do

- Does not modify the canonical form (still `byteme/blid/v1`, frozen)
- Does not pressure adoption — the spec is documented, using it is the receiving lane's call
- Does not transport payloads, only enables identity convergence

Auto-route: this PR exists because branch protection on `develop` correctly blocked the direct push. The discipline now enforces itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ZmJoAzeo4ZKpSPCCW6ZL)_